### PR TITLE
Menu bar fixes

### DIFF
--- a/components/menu-bar/index.tsx
+++ b/components/menu-bar/index.tsx
@@ -264,7 +264,7 @@ function Trigger({
 }) {
   return (
     <Menubar.Trigger
-      className={`outline-none cursor-default data-[state=open]:bg-black/10 dark:data-[state=open]:bg-white/10 rounded-1 px-2 h-[25px] ${
+      className={`outline-none cursor-default data-[state=open]:bg-black/10 focus:bg-black/10 dark:data-[state=open]:bg-white/10 dark:focus:bg-white/10 rounded-1 px-2 h-[25px] ${
         bold ? "font-semibold" : undefined
       }`}
     >

--- a/components/theme-navigation.tsx
+++ b/components/theme-navigation.tsx
@@ -26,7 +26,10 @@ export function ThemeNavigation({ themes }: { themes: Theme[] }) {
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (document.activeElement?.closest("[data-radix-menubar-content]")) {
+      if (
+        document.activeElement?.closest('[role="menubar"]') ||
+        document.activeElement?.closest("[data-radix-menubar-content]")
+      ) {
         return;
       }
 


### PR DESCRIPTION
A couple of improvements to the menu bar:
- Stop the arrow keys from changing the theme when the focus is on the menu bar. Until now, the logic to prevent the arrow keys from changing the theme only worked when the menu bar was open.
- Add a focus state to menu bar items. The focus state is the same as the current open state.

**Before**

Notice how the theme changes when pressing the ⬅️ ➡️ keys when the menu bar contains the focus. Red outline added for demo purposes.

https://github.com/raycast/theme-explorer/assets/7225802/de5688cd-eba5-477e-ae99-eaf48ad6edbe

**After**

The theme doesn't change when pressing the ⬅️ ➡️ keys when the menu bar contains the focus. You can also see the focus state working.

https://github.com/raycast/theme-explorer/assets/7225802/a541756c-306b-445a-b1bb-9960baaed550


