### PR TITLE
Create atom-one-dark.json

### DIFF
--- a/themes/mackomaxo/atom-one-dark.json
+++ b/themes/mackomaxo/atom-one-dark.json
@@ -1,0 +1,20 @@
+{  "author": "Macko++",
+  "authorUsername": "MackoMaxo",
+  "version": "1",
+  "name": "Atom One Dark",
+  "appearance": "dark",
+  "colors": {
+    "background": "#282C34",
+    "backgroundSecondary": "#282C34",
+    "text": "#C0C7D6",
+    "selection": "#528BFF",
+    "loader": "#528BFF",
+    "red": "#BE6A46",
+    "orange": "#D19A66",
+    "yellow": "#E5C07B",
+    "green": "#98C379",
+    "blue": "#61AFEF",
+    "purple": "#C678DD",
+    "magenta": "#56B6C2"
+  }
+}


### PR DESCRIPTION
This theme is a reproduction of the popular Atom One Dark theme.

<a href="https://themes.ray.so?version=1&name=Atom%20One%20Dark&author=Macko++&authorUsername=MackoMaxo&colors=%23282C34,%23282C34,%23C0C7D6,%23528BFF,%23528BFF,%23BE6A46,%23D19A66,%23E5C07B,%2398C379,%2361AFEF,%23C678DD,%2356B6C2&appearance=dark&addToRaycast">Here</a> is the preview/install link for the theme.

<img width="832" alt="image" src="https://github.com/raycast/theme-explorer/assets/82177845/c16b2208-54ba-4455-8962-5166d4ebc801">
